### PR TITLE
Fix timestamptz_in breaking on half-hour timezones

### DIFF
--- a/pg8000/converters.py
+++ b/pg8000/converters.py
@@ -220,7 +220,16 @@ def timestamp_in(data):
 
 def timestamptz_in(data):
     patt = "%Y-%m-%d %H:%M:%S.%f%z" if "." in data else "%Y-%m-%d %H:%M:%S%z"
-    return Datetime.strptime(data + "00", patt)
+    tz_sign = '+' if '+' in data else ('-' if data.count('-') == 3 else None)
+    if tz_sign is None:
+        tz_sign = '+'
+        timestamp, tz = data, "0000"
+    else:
+        tz_sign_index = data.rfind(tz_sign)
+        timestamp, tz = data[:tz_sign_index], data[tz_sign_index+1:]
+    tz = tz.replace(':', '').ljust(4, '0')
+    data = "{:s}{:s}{:s}".format(timestamp, tz_sign, tz)
+    return Datetime.strptime(data, patt)
 
 
 def unknown_out(v):

--- a/test/native/test_converters.py
+++ b/test/native/test_converters.py
@@ -234,16 +234,18 @@ def test_interval_in(value, expected):
 
 def test_timestamptz_in():
     now = DateTime.now()
-    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + "+01:30") == \
-           now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=1, minutes=30)))
-    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + "+02") == \
-           now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=2)))
+    for tz_sign in ('+', '-'):
+        tz_mul = 1 if tz_sign == '+' else -1
+        assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + tz_sign + "01:30") == \
+               now.replace(microsecond=0, tzinfo=TimeZone(tz_mul * TimeDelta(hours=1, minutes=30)))
+        assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + tz_sign + "02") == \
+               now.replace(microsecond=0, tzinfo=TimeZone(tz_mul * TimeDelta(hours=2)))
+        assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f") + tz_sign +"01:30") == \
+               now.replace(tzinfo=TimeZone(tz_mul * TimeDelta(hours=1, minutes=30)))
+        assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f") + tz_sign + "02") == \
+               now.replace(tzinfo=TimeZone(tz_mul * TimeDelta(hours=2)))
     assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S")) == \
            now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=0)))
-    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f")+"+01:30") == \
-           now.replace(tzinfo=TimeZone(TimeDelta(hours=1, minutes=30)))
-    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f") + "+02") == \
-           now.replace(tzinfo=TimeZone(TimeDelta(hours=2)))
     assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f")) == \
            now.replace(tzinfo=TimeZone(TimeDelta(hours=0)))
 

--- a/test/native/test_converters.py
+++ b/test/native/test_converters.py
@@ -3,6 +3,7 @@ from datetime import (
     datetime as DateTime,
     time as Time,
     timedelta as TimeDelta,
+    timezone as TimeZone,
 )
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv4Network
@@ -25,6 +26,7 @@ from pg8000.converters import (
     pg_interval_in,
     string_in,
     string_out,
+    timestamptz_in,
 )
 from pg8000.native import InterfaceError
 
@@ -228,6 +230,22 @@ def test_pg_interval_in(value, expected):
 )
 def test_interval_in(value, expected):
     assert interval_in(value) == expected
+
+
+def test_timestamptz_in():
+    now = DateTime.now()
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + "+01:30") == \
+           now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=1, minutes=30)))
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S") + "+02") == \
+           now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=2)))
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S")) == \
+           now.replace(microsecond=0, tzinfo=TimeZone(TimeDelta(hours=0)))
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f")+"+01:30") == \
+           now.replace(tzinfo=TimeZone(TimeDelta(hours=1, minutes=30)))
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f") + "+02") == \
+           now.replace(tzinfo=TimeZone(TimeDelta(hours=2)))
+    assert timestamptz_in(now.strftime("%Y-%m-%d %H:%M:%S.%f")) == \
+           now.replace(tzinfo=TimeZone(TimeDelta(hours=0)))
 
 
 def test_array_string_escape():


### PR DESCRIPTION
`timestamptz_in` would naively add '00' to the end of a timestamp before parsing it.  This caused issues when timestamps with half-hour timezones were used.


For example, a timestamp ending in '+01:30' would become '+01:3000', which is invalid because the use of ':' is inconsistent.

This PR  fixes this by right padding the supplied timezone offset with zeros to a length of at least 4, and removes all colons from the offset for consistency. Timestamps without any timezone offset will be treated as UTC.