### PR TITLE
Hardcode version 1.29.1+j5.2

### DIFF
--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-ver = "1.29.1+j5.1"
+ver = "1.29.1+j5.2"
 
 
 def pack_funcs(fmt):

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-ver = "1.29.1+j5.2"
+ver = "1.29.1+j5.3"
 
 
 def pack_funcs(fmt):

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-ver = "1.29.1+j5.3"
+ver = "1.29.1+j5.2"
 
 
 def pack_funcs(fmt):

--- a/pg8000/core.py
+++ b/pg8000/core.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from importlib_metadata import version
 
-ver = version("pg8000")
+ver = "1.29.1+j5.1"
 
 
 def pack_funcs(fmt):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pg8000
-version = 1.29.1+j5.3
+version = 1.29.1+j5.2
 author = Mathieu Fenniak And Contributors
 description = PostgreSQL interface library
 long_description = pg8000

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = pg8000
+version = 1.29.1+j5.2
 author = Mathieu Fenniak And Contributors
 description = PostgreSQL interface library
 long_description = pg8000

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pg8000
-version = 1.29.1+j5.2
+version = 1.29.1+j5.3
 author = Mathieu Fenniak And Contributors
 description = PostgreSQL interface library
 long_description = pg8000


### PR DESCRIPTION
Pip seems to think the version is `0.0.0` without this. So we need to hardcode the version as `1.29.1+j5.2`.